### PR TITLE
[FIX] Update PyMuPDF to 1.26.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyMuPDF==1.26.4
+PyMuPDF==1.26.7
 mammoth==1.9.0
 pytesseract
 pillow-heif


### PR DESCRIPTION
Version 1.26.4 on Odoo.sh raises the following warnings when the module is loaded. We update to the latest version 1.26.7. I didn't pinpoint in the MuPDF changelog what fixes these warning, maybe the change in supported python versions?

DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
DeprecationWarning: builtin type swigvarlink has no __module__ attribute